### PR TITLE
eric/document-domain-change

### DIFF
--- a/sdk/dotnet.md
+++ b/sdk/dotnet.md
@@ -89,6 +89,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed:
 
 - Added format field to us-street api.
+- Changed default domain for all apis to *.api.smarty.com (was *.api.smartystreets.com). This change could affect firewall rules that allowed only the previous domain name
 
 ## [8.14.0] - 2023-07-06
 

--- a/sdk/go.md
+++ b/sdk/go.md
@@ -114,6 +114,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Added "selected" field to us-autocomplete-pro-api lookup struct.
 
+## [v1.16.1] - 2023-7-26
+
+### Changed:
+
+- Changed default domain for all apis to *.api.smarty.com (was *.api.smartystreets.com). This change could affect firewall rules that allowed only the previous domain name
+
 ## [1.16.0] - 2023-06-29
 
 ### Changed:

--- a/sdk/ios.md
+++ b/sdk/ios.md
@@ -68,7 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed:
 
 - Added format field to us-street api.
-
+- Changed default domain for all apis to *.api.smarty.com (was *.api.smartystreets.com). This change could affect firewall rules that allowed only the previous domain name
 
 ## [8.11.0] - 2023-07-06
 

--- a/sdk/java.md
+++ b/sdk/java.md
@@ -86,7 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed:
 
 - Added format field to us-street api.
-
+- Changed default domain for all apis to *.api.smarty.com (was *.api.smartystreets.com). This change could affect firewall rules that allowed only the previous domain name
 
 ## [3.14.0] - 2023-07-06
 

--- a/sdk/php.md
+++ b/sdk/php.md
@@ -99,7 +99,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed:
 
 - Added format field to us-street api.
-
+- Changed default domain for all apis to *.api.smarty.com (was *.api.smartystreets.com). This change could affect firewall rules that allowed only the previous domain name
 
 ## [4.17.0] - 2023-07-06
 

--- a/sdk/python.md
+++ b/sdk/python.md
@@ -96,7 +96,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed:
 
 - Added format field to us-street api.
-
+- Changed default domain for all apis to *.api.smarty.com (was *.api.smartystreets.com). This change could affect firewall rules that allowed only the previous domain name
 
 ## [4.12.0] - 2023-07-06
 

--- a/sdk/ruby.md
+++ b/sdk/ruby.md
@@ -115,7 +115,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed:
 
 - Added format field to us-street api.
-
+- Changed default domain for all apis to *.api.smarty.com (was *.api.smartystreets.com). This change could affect firewall rules that allowed only the previous domain name
 
 ## [5.15.0] - 2023-07-06
 


### PR DESCRIPTION
Added domain change documentation for all SDKs aside from Javascript (already documented) and Rust (this change predates the Rust changelog)